### PR TITLE
优化导出xlsx的格式

### DIFF
--- a/StarRailTool/Properties/launchSettings.json
+++ b/StarRailTool/Properties/launchSettings.json
@@ -1,7 +1,12 @@
 {
   "profiles": {
-    "SrTool": {
-      "commandName": "Project"
+    "get": {
+      "commandName": "Project",
+      "commandLineArgs": "gacha get"
+    },
+    "export": {
+      "commandName": "Project",
+      "commandLineArgs": "gacha export 102572035 -output C:\\Users\\25389\\Desktop\\102572035.xlsx"
     }
   }
 }

--- a/StarRailTool/StarRailTool.csproj
+++ b/StarRailTool/StarRailTool.csproj
@@ -36,6 +36,7 @@
 	<ItemGroup>
 		<PackageReference Include="ConsoleTableExt" Version="3.2.0" />
 		<PackageReference Include="Dapper" Version="2.0.123" />
+		<PackageReference Include="EPPlus" Version="6.2.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
 		<PackageReference Include="MiniExcel" Version="1.30.2" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
使用EEPlus，优化了导出的excel表格的格式：
1. 删除表头的冗余信息，仅保留“时间”、“名称”、“物品类型”、“稀有度”、“保底内排序”，新增“总次数”
2. 为四星和五星物品增加颜色提示（紫色和金色）
3. 表格列宽设置为“自动调整列宽”
对比：
原格式
![原格式](https://user-images.githubusercontent.com/78953666/236866993-ceb56072-b206-430a-b462-21916c668b87.png)
新格式
![新格式](https://user-images.githubusercontent.com/78953666/236867024-59e574b9-f227-441a-b820-f65f3ed72708.png)

